### PR TITLE
BTFS-1282: Fix panic on setting error race condition

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 Jeromy Johnson
+Copyright (c) 2020 TRON-US
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,23 +1,11 @@
 go-ipld-format
 ==================
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Coverage Status](https://codecov.io/gh/ipfs/go-ipld-format/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/go-ipld-format/branch/master)
-[![Travis CI](https://travis-ci.org/ipfs/go-ipld-format.svg?branch=master)](https://travis-ci.org/ipfs/go-ipld-format)
-
 > go-ipld-format is a set of interfaces that a type needs to implement in order to be a part of the ipld merkle-forest.
-
-## Lead Maintainer
-
-[Eric Myhre](https://github.com/warpfork)
 
 ## Table of Contents
 
 - [Install](#install)
-- [Usage](#usage)
-- [API](#api)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -35,4 +23,4 @@ Small note: If editing the Readme, please conform to the [standard-readme](https
 
 ## License
 
-MIT © Jeromy Johnson
+MIT © TRON-US

--- a/batch.go
+++ b/batch.go
@@ -88,7 +88,9 @@ func (t *Batch) asyncCommit() {
 				return
 			}
 		case <-t.ctx.Done():
-			t.setError(t.ctx.Err())
+			if t.ctx != nil {
+				t.setError(t.ctx.Err())
+			}
 			return
 		}
 	}
@@ -153,7 +155,9 @@ loop:
 				break loop
 			}
 		case <-t.ctx.Done():
-			t.setError(t.ctx.Err())
+			if t.ctx != nil {
+				t.setError(t.ctx.Err())
+			}
 			break loop
 		}
 	}
@@ -162,6 +166,10 @@ loop:
 }
 
 func (t *Batch) setError(err error) {
+	if t.err != nil {
+		return
+	}
+
 	t.err = err
 
 	t.cancel()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/TRON-US/go-ipld-format
+module github.com/ipfs/go-ipld-format
 
 require (
 	github.com/ipfs/go-block-format v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
-module github.com/ipfs/go-ipld-format
+module github.com/TRON-US/go-ipld-format
 
 require (
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.2
 	github.com/multiformats/go-multihash v0.0.1
 )
+
+go 1.13


### PR DESCRIPTION
Also update readme and license for TRON-US version

Note that the module path is intentionally kept at github.com/ipfs/go-ipld-format for easy replacement/bug-fixing existing libraries.